### PR TITLE
passes attributes when creating activity

### DIFF
--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -158,7 +158,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       sharedDefault!.set(item.value, forKey: item.key)
     }
     
-    let liveDeliveryAttributes = LiveActivitiesAppAttributes()
+    let liveDeliveryAttributes = LiveActivitiesAppAttributes(data)
     let initialContentState = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: appGroupId!)
     
     do {


### PR DESCRIPTION
#19 pass data into attributes when creating activity so that you don't have to rely on shared defaults. Don't merge right away I want to have a discussion around this because I feel like there was a reason this wasn't done.