### PR TITLE
creating an activity can now use stale-date

### DIFF
--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -20,14 +20,20 @@ class LiveActivities {
   /// When the activity is created, an activity id is returned.
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Image are limited by size, be sure to pass only small images (you can use ```resizeFactor```).
+  ///
+  /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
+  /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
+  /// iOS 16.2+ and does nothing on on iOS 16.1
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
+    Duration? staleIn,
   }) async {
     await _appGroupsImageService.sendImageToAppGroups(data);
     return LiveActivitiesPlatform.instance.createActivity(
       data,
       removeWhenAppIsKilled: removeWhenAppIsKilled,
+      staleIn: staleIn,
     );
   }
 
@@ -113,6 +119,5 @@ class LiveActivities {
   ///   active: (state) { ... },
   /// ))
   /// ```
-  Stream<ActivityUpdate> get activityUpdateStream =>
-      LiveActivitiesPlatform.instance.activityUpdateStream;
+  Stream<ActivityUpdate> get activityUpdateStream => LiveActivitiesPlatform.instance.activityUpdateStream;
 }

--- a/lib/live_activities_method_channel.dart
+++ b/lib/live_activities_method_channel.dart
@@ -16,12 +16,10 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
   final methodChannel = const MethodChannel('live_activities');
 
   @visibleForTesting
-  final activityStatusChannel =
-      const EventChannel('live_activities/activity_status');
+  final activityStatusChannel = const EventChannel('live_activities/activity_status');
 
   @visibleForTesting
-  final EventChannel urlSchemeChannel =
-      const EventChannel('live_activities/url_scheme');
+  final EventChannel urlSchemeChannel = const EventChannel('live_activities/url_scheme');
 
   @override
   Future init(String appGroupId) async {
@@ -34,10 +32,14 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
+    Duration? staleIn,
   }) async {
+    // If the duration is less than 1 minute then pass a null value instead of using 0 minutes
+    final staleInMinutes = (staleIn?.inMinutes ?? 0) >= 1 ? staleIn?.inMinutes : null;
     return methodChannel.invokeMethod<String>('createActivity', {
       'data': data,
       'removeWhenAppIsKilled': removeWhenAppIsKilled,
+      'staleIn': staleInMinutes,
     });
   }
 
@@ -63,23 +65,20 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
 
   @override
   Future<List<String>> getAllActivitiesIds() async {
-    final result =
-        await methodChannel.invokeListMethod<String>('getAllActivitiesIds');
+    final result = await methodChannel.invokeListMethod<String>('getAllActivitiesIds');
     return result ?? [];
   }
 
   @override
   Future<bool> areActivitiesEnabled() async {
-    final result =
-        await methodChannel.invokeMethod<bool>('areActivitiesEnabled');
+    final result = await methodChannel.invokeMethod<bool>('areActivitiesEnabled');
     return result ?? false;
   }
 
   @override
   Stream<UrlSchemeData> urlSchemeStream() {
     return urlSchemeChannel.receiveBroadcastStream('urlSchemeStream').map(
-          (dynamic event) =>
-              UrlSchemeData.fromMap(Map<String, dynamic>.from(event)),
+          (dynamic event) => UrlSchemeData.fromMap(Map<String, dynamic>.from(event)),
         );
   }
 

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -33,6 +33,7 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
+    Duration? staleIn,
   }) {
     throw UnimplementedError('createActivity() has not been implemented.');
   }
@@ -54,8 +55,7 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
   }
 
   Future<bool> areActivitiesEnabled() {
-    throw UnimplementedError(
-        'areActivitiesEnabled() has not been implemented.');
+    throw UnimplementedError('areActivitiesEnabled() has not been implemented.');
   }
 
   Stream<UrlSchemeData> urlSchemeStream() {


### PR DESCRIPTION
The only way to have a stale-date for the activity is through a notification, but if the user never receives a notification we are unable to set a stale-date to indicate out of date data.

Added an option to set the stale-date when creating the activity, it can then be updated via push notifications.