### PR TITLE
make sure deliveryActivity isn't null before using

### DIFF
--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -190,14 +190,13 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         result(FlutterError(code: "LIVE_ACTIVITY_ERROR", message: "can't launch live activity", details: error.localizedDescription))
       }
     }
-    if removeWhenAppIsKilled {
-      appLifecycleLifeActiviyIds.append(deliveryActivity!.id)
+    if (deliveryActivity != nil) {
+      if removeWhenAppIsKilled {
+        appLifecycleLifeActiviyIds.append(deliveryActivity!.id)
+      }
+      monitorLiveActivity(deliveryActivity!)
+      result(deliveryActivity!.id)
     }
-    monitorLiveActivity(deliveryActivity!)
-    result(deliveryActivity!.id)
-    
-    
-
   }
   
   @available(iOS 16.1, *)


### PR DESCRIPTION
Just add a null check to make sure deliveryActivity isn't null before using. Related bug #40 