### PR TITLE
Adds sinks unregister on engine end

### DIFF
--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -21,6 +21,11 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     activityStatusChannel.setStreamHandler(instance)
     registrar.addApplicationDelegate(instance)
   }
+
+  public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+      urlSchemeSink = nil
+      activityEventSink = nil
+  }
   
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     if let args = arguments as? String{


### PR DESCRIPTION
Summary: Unregister the sinks when the Flutter engine gets destroyed.

TLDR: The reason why this is necessary is because the activities can be updated and ended by using push notifications (as described in the project README). This makes possible that this function gets invoked when the app, and as a consequence Flutter engine, are killed:

https://github.com/istornz/flutter_live_activities/blob/c07dd45124b3a36a1d5583b01f5cd23c40b9b60a/ios/Classes/SwiftLiveActivitiesPlugin.swift#L341-L361

And why this is an issue? Because the app will raise the following exception:

`Fatal Exception: NSInternalInconsistencyException Sending a message before the FlutterEngine has been run.`.

This doesn't produce any visual inconsistency in the app, but will pollute crash tools why this fatal exception.

A more in depth discussion can be found in the following links

- https://github.com/flutter/flutter/issues/96901
- https://github.com/flutter/flutter/issues/135613