### PR TITLE
Add prefix for shared preference usage

### DIFF
--- a/example/ios/extension-example/extension_example.swift
+++ b/example/ios/extension-example/extension_example.swift
@@ -34,20 +34,20 @@ let sharedDefault = UserDefaults(suiteName: "group.dimitridessus.liveactivities"
 struct FootballMatchApp: Widget {
   var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivitiesAppAttributes.self) { context in
-      let matchName = sharedDefault.string(forKey: "matchName")!
+      let matchName = sharedDefault.string(forKey: context.attributes.prefixedKey("matchName"))!
       
-      let teamAName = sharedDefault.string(forKey: "teamAName")!
-      let teamAState = sharedDefault.string(forKey: "teamAState")!
-      let teamAScore = sharedDefault.integer(forKey: "teamAScore")
-      let teamALogo = sharedDefault.string(forKey: "teamALogo")!
+      let teamAName = sharedDefault.string(forKey: context.attributes.prefixedKey("teamAName"))!
+      let teamAState = sharedDefault.string(forKey: context.attributes.prefixedKey("teamAState"))!
+      let teamAScore = sharedDefault.integer(forKey: context.attributes.prefixedKey("teamAScore"))
+      let teamALogo = sharedDefault.string(forKey: context.attributes.prefixedKey("teamALogo"))!
       
-      let teamBName = sharedDefault.string(forKey: "teamBName")!
-      let teamBState = sharedDefault.string(forKey: "teamBState")!
-      let teamBScore = sharedDefault.integer(forKey: "teamBScore")
-      let teamBLogo = sharedDefault.string(forKey: "teamBLogo")!
+      let teamBName = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBName"))!
+      let teamBState = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBState"))!
+      let teamBScore = sharedDefault.integer(forKey: context.attributes.prefixedKey("teamBScore"))
+      let teamBLogo = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBLogo"))!
       
-      let matchStartDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: "matchStartDate") / 1000)
-      let matchEndDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: "matchEndDate") / 1000)
+      let matchStartDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: context.attributes.prefixedKey("matchStartDate")) / 1000)
+      let matchEndDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: context.attributes.prefixedKey("matchEndDate")) / 1000)
       let matchRemainingTime = matchStartDate...matchEndDate
       
       ZStack {
@@ -161,20 +161,20 @@ struct FootballMatchApp: Widget {
         .padding(.horizontal, 2.0)
       }.frame(height: 160)
     } dynamicIsland: { context in
-      let matchName = sharedDefault.string(forKey: "matchName")!
+      let matchName = sharedDefault.string(forKey: context.attributes.prefixedKey("matchName"))!
       
-      let teamAName = sharedDefault.string(forKey: "teamAName")!
-      let teamAState = sharedDefault.string(forKey: "teamAState")!
-      let teamAScore = sharedDefault.integer(forKey: "teamAScore")
-      let teamALogo = sharedDefault.string(forKey: "teamALogo")!
+      let teamAName = sharedDefault.string(forKey: context.attributes.prefixedKey("teamAName"))!
+      let teamAState = sharedDefault.string(forKey: context.attributes.prefixedKey("teamAState"))!
+      let teamAScore = sharedDefault.integer(forKey: context.attributes.prefixedKey("teamAScore"))
+      let teamALogo = sharedDefault.string(forKey: context.attributes.prefixedKey("teamALogo"))!
       
-      let teamBName = sharedDefault.string(forKey: "teamBName")!
-      let teamBState = sharedDefault.string(forKey: "teamBState")!
-      let teamBScore = sharedDefault.integer(forKey: "teamBScore")
-      let teamBLogo = sharedDefault.string(forKey: "teamBLogo")!
+      let teamBName = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBName"))!
+      let teamBState = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBState"))!
+      let teamBScore = sharedDefault.integer(forKey: context.attributes.prefixedKey("teamBScore"))
+      let teamBLogo = sharedDefault.string(forKey: context.attributes.prefixedKey("teamBLogo"))!
       
-      let matchStartDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: "matchStartDate") / 1000)
-      let matchEndDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: "matchEndDate") / 1000)
+      let matchStartDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: context.attributes.prefixedKey("matchStartDate")) / 1000)
+      let matchEndDate = Date(timeIntervalSince1970: sharedDefault.double(forKey: context.attributes.prefixedKey("matchEndDate")) / 1000)
       let matchRemainingTime = matchStartDate...matchEndDate
       
       return DynamicIsland {
@@ -326,4 +326,10 @@ struct FootballMatchApp: Widget {
       }
     }
   }
+}
+
+extension LiveActivitiesAppAttributes {
+    func prefixedKey(key: String) -> String {
+        return "\(id)_\(key)"
+    }
 }

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -167,14 +167,17 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         result(FlutterError(code: "AUTHORIZATION_ERROR", message: "authorization error", details: error.localizedDescription))
       }
     }
-    
-    for item in data {
-      sharedDefault!.set(item.value, forKey: item.key)
-    }
+
     
     let liveDeliveryAttributes = LiveActivitiesAppAttributes()
     let initialContentState = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: appGroupId!)
     var deliveryActivity: Activity<LiveActivitiesAppAttributes>?
+    let prefix = liveDeliveryAttributes.id
+      
+    for item in data {
+        sharedDefault!.set(item.value, forKey: "\(prefix)_\(item.key)")
+    }
+ 
     if #available(iOS 16.2, *){
       let activityContent = ActivityContent(
         state: initialContentState,
@@ -212,11 +215,13 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     Task {
       for activity in Activity<LiveActivitiesAppAttributes>.activities {
         if activityId == activity.id {
+          let prefix = activity.attributes.id
+
           for item in data {
             if (item.value != nil && !(item.value is NSNull)) {
-              sharedDefault!.set(item.value, forKey: item.key)
+              sharedDefault!.set(item.value, forKey: "\(prefix)_\(item.key)")
             } else {
-              sharedDefault!.removeObject(forKey: item.key)
+              sharedDefault!.removeObject(forKey: "\(prefix)_\(item.key)")
             }
           }
           


### PR DESCRIPTION
Based on my comment in #19, it is not possible to use multiple live activities simultaneously due to the use of `UserDefaults` to transfer data from Flutter to the live activity. However, to resolve this issue, I added a prefix to all of the stored values in `UserDefaults` using the ID set via `LiveActivitiesAppAttributes`. This modification enables the use of multiple live activities without any conflict.

For now, this is just a discussion. I was able to successfully test my implementation for local creations and updates but not for remote updates yet.