### PR TITLE
#53 - Fix stall state for unknown activityId

### DIFF
--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -246,8 +246,11 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
           @unknown default:
             result("unknown")
           }
+          return // Exit the function after calling result
         }
       }
+      // No matching activity was found
+      result("unknown")
     }
   }
   
@@ -365,6 +368,8 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
           activityEventSink?.self(response)
         }
       }
+      // No matching activity was found
+      result("unknown")
     }
   }
   

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -232,25 +232,23 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   @available(iOS 16.1, *)
   func getActivityState(activityId: String, result: @escaping FlutterResult) {
     Task {
-      for activity in Activity<LiveActivitiesAppAttributes>.activities {
-        if (activityId == activity.id) {
-          switch (activity.activityState) {
-          case .active:
-            result("active")
-          case .ended:
-            result("ended")
-          case .dismissed:
-            result("dismissed")
-          case .stale:
-            result("stale")
-          @unknown default:
-            result("unknown")
-          }
-          return // Exit the function after calling result
+      if let matchingActivity = Activity<LiveActivitiesAppAttributes>.activities.first(where: { $0.id == activityId }) {
+        switch (matchingActivity.activityState) {
+        case .active:
+          result("active")
+        case .ended:
+          result("ended")
+        case .dismissed:
+          result("dismissed")
+        case .stale:
+          result("stale")
+        @unknown default:
+          result("unknown")
         }
+      } else {
+        // No matching activity was found
+        result("unknown")
       }
-      // No matching activity was found
-      result("unknown")
     }
   }
   
@@ -368,8 +366,6 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
           activityEventSink?.self(response)
         }
       }
-      // No matching activity was found
-      result("unknown")
     }
   }
   


### PR DESCRIPTION
Fixes #53.
On the Flutter side, ensures completion of the future even if the provided `activityId` is not found in the active live activity list on the iOS side.

Discussion: It is unclear whether returning an error or an unknown state is more beneficial when the activity ID is unknown.