### PR TITLE
Update stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </div>
 <br />
 
-A Flutter plugin to use iOS 16.1+ **Live Activities** & iPhone 14 Pro **Dynamic Island** features.
+A Flutter plugin to use iOS 16.2+ **Live Activities** & iPhone 14 Pro **Dynamic Island** features.
 
 ## 🧐 What is it ?
 
@@ -27,8 +27,8 @@ This plugin uses the [iOS ActivityKit API](https://developer.apple.com/documenta
 
 **live_activities** can be used to show **dynamic live notification** & implement **dynamic island** feature on iPhones that support it 🏝️
 
-> ⚠️ **live_activities** is only intended to use with **iOS 16.1+** !
-> It will simply do nothing on other platform & < iOS 16.1
+> ⚠️ **live_activities** is only intended to use with **iOS 16.2+** !
+> It will simply do nothing on other platform & < iOS 16.2
 
 <br />
 <div align="center" style="display: flex;align-items: center;justify-content: center;">

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					27C0558128E42F5700BA744B = {
@@ -510,7 +510,7 @@
 				INFOPLIST_FILE = "extension-example/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "extension-example";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -550,7 +550,7 @@
 				INFOPLIST_FILE = "extension-example/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "extension-example";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -587,7 +587,7 @@
 				INFOPLIST_FILE = "extension-example/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "extension-example";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/extension-example/extension_example.swift
+++ b/example/ios/extension-example/extension_example.swift
@@ -12,7 +12,7 @@ import SwiftUI
 @main
 struct Widgets: WidgetBundle {
   var body: some Widget {
-    if #available(iOS 16.1, *) {
+    if #available(iOS 16.2, *) {
       FootballMatchApp()
     }
   }
@@ -30,7 +30,7 @@ struct LiveActivitiesAppAttributes: ActivityAttributes, Identifiable {
 // Create shared default with custom group
 let sharedDefault = UserDefaults(suiteName: "group.dimitridessus.liveactivities")!
 
-@available(iOSApplicationExtension 16.1, *)
+@available(iOSApplicationExtension 16.2, *)
 struct FootballMatchApp: Widget {
   var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivitiesAppAttributes.self) { context in

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,6 +160,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -174,39 +198,39 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.1"
+    version: "1.9.1+1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -332,6 +356,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   web:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -192,7 +192,6 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         result(FlutterError(code: "AUTHORIZATION_ERROR", message: "authorization error", details: error.localizedDescription))
       }
     }
-
     
     let liveDeliveryAttributes = LiveActivitiesAppAttributes()
     let initialContentState = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: appGroupId!)
@@ -420,6 +419,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
 
+  @available(iOS 16.1, *)
   func getStaleDate(staleIn: Int?) -> Date? {
     if staleIn != nil {
       return Calendar.current.date(byAdding: .minute, value: staleIn!, to: Date.now)

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -2,7 +2,7 @@ import ActivityKit
 import Flutter
 import UIKit
 
-@available(iOS 16.1, *)
+@available(iOS 16.2, *)
 class FlutterAlertConfig {
   let _title:String
   let _body:String
@@ -76,7 +76,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     if (call.method == "areActivitiesEnabled") {
-      if #available(iOS 16.1, *) {
+      if #available(iOS 16.2, *) {
         result(ActivityAuthorizationInfo().areActivitiesEnabled)
       } else {
         result(false)
@@ -84,7 +84,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       return
     }
     
-    if #available(iOS 16.1, *) {
+    if #available(iOS 16.2, *) {
       switch call.method {
         case "init":
           guard let args = call.arguments as? [String: Any] else {
@@ -183,7 +183,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func createActivity(data: [String: Any], removeWhenAppIsKilled: Bool, staleIn: Int?, result: @escaping FlutterResult) {
     let center = UNUserNotificationCenter.current()
     center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
@@ -234,7 +234,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func updateActivity(activityId: String, data: [String: Any?], alertConfig: FlutterAlertConfig?, staleIn: Int?, result: @escaping FlutterResult) {
     Task {
       for activity in Activity<LiveActivitiesAppAttributes>.activities {
@@ -259,7 +259,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   }
 
 
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func getActivityState(activityId: String, result: @escaping FlutterResult) {
     Task {
       if let matchingActivity = Activity<LiveActivitiesAppAttributes>.activities.first(where: { $0.id == activityId }) {
@@ -282,7 +282,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func getPushToken(activityId: String, result: @escaping FlutterResult) {
     Task {
       var pushToken: String?;
@@ -297,7 +297,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func endActivity(activityId: String, result: @escaping FlutterResult) {
     appLifecycleLifeActiviyIds.removeAll { $0 == activityId }
     Task {
@@ -306,7 +306,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func endAllActivities(result: @escaping FlutterResult) {
     Task {
       for activity in Activity<LiveActivitiesAppAttributes>.activities {
@@ -317,7 +317,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func getAllActivitiesIds(result: @escaping FlutterResult) {
     var activitiesId: [String] = []
     for activity in Activity<LiveActivitiesAppAttributes>.activities {
@@ -327,7 +327,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     result(activitiesId)
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   private func endActivitiesWithId(activityIds: [String]) async {
     for activity in Activity<LiveActivitiesAppAttributes>.activities {
       if (activityIds.contains { $0 == activity.id }) {
@@ -359,7 +359,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   }
   
   public func applicationWillTerminate(_ application: UIApplication) {
-    if #available(iOS 16.1, *) {
+    if #available(iOS 16.2, *) {
       Task {
         await self.endActivitiesWithId(activityIds: self.appLifecycleLifeActiviyIds)
       }
@@ -376,7 +376,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     var id = UUID()
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   private func monitorLiveActivity<T : ActivityAttributes>(_ activity: Activity<T>) {
       do {
           try
@@ -405,7 +405,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       }
   }
   
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   private func monitorTokenChanges<T: ActivityAttributes>(_ activity: Activity<T>) {
     Task {
       for await data in activity.pushTokenUpdates {
@@ -419,7 +419,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
 
-  @available(iOS 16.1, *)
+  @available(iOS 16.2, *)
   func getStaleDate(_ staleIn: Int?) -> Date? {
     if staleIn != nil {
       return Calendar.current.date(byAdding: .minute, value: staleIn!, to: Date.now)

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -229,7 +229,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       if removeWhenAppIsKilled {
         appLifecycleLifeActiviyIds.append(deliveryActivity!.id)
       }
-      monitorLiveActivity(deliveryActivity!)
+//       monitorLiveActivity(deliveryActivity!)
       result(deliveryActivity!.id)
     }
   }

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -420,7 +420,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   }
 
   @available(iOS 16.1, *)
-  func getStaleDate(staleIn: Int?) -> Date? {
+  func getStaleDate(_ staleIn: Int?) -> Date? {
     if staleIn != nil {
       return Calendar.current.date(byAdding: .minute, value: staleIn!, to: Date.now)
     }

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -376,28 +376,34 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     var id = UUID()
   }
   
-  @available(iOS 16.1, *)
-  private func monitorLiveActivity<T : ActivityAttributes>(_ activity: Activity<T>) {
-    Task {
-      for await state in activity.activityStateUpdates {
-        var response: Dictionary<String, Any> = Dictionary()
-        response["activityId"] = activity.id
-        switch state {
-        case .active:
-          monitorTokenChanges(activity)
-        case .dismissed, .ended:
-          response["status"] = "ended"
-          activityEventSink?.self(response)
-        case .stale:
-          response["status"] = "stale"
-          activityEventSink?.self(response)
-        @unknown default:
-          response["status"] = "unknown"
-          activityEventSink?.self(response)
-        }
-      }
-    }
-  }
+//   @available(iOS 16.1, *)
+//   private func monitorLiveActivity<T : ActivityAttributes>(_ activity: Activity<T>) {
+//       do {
+//           try
+//           Task {
+//             for await state in activity.activityStateUpdates {
+//               var response: Dictionary<String, Any> = Dictionary()
+//               response["activityId"] = activity.id
+//               switch state {
+//               case .active:
+//                 monitorTokenChanges(activity)
+//               case .dismissed, .ended:
+//                 response["status"] = "ended"
+//                 activityEventSink?.self(response)
+//               case .stale:
+//                 response["status"] = "stale"
+//                 activityEventSink?.self(response)
+//               @unknown default:
+//                 response["status"] = "unknown"
+//                 activityEventSink?.self(response)
+//               }
+//             }
+//           }
+//       } catch {
+//           print("error: ");
+//           print(error);
+//       }
+//   }
   
   @available(iOS 16.1, *)
   private func monitorTokenChanges<T: ActivityAttributes>(_ activity: Activity<T>) {

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -20,14 +20,13 @@ class LiveActivities {
     );
   }
 
-  /// Create an iOS 16.2+ live activity.
+  /// Create a live activity.
   /// When the activity is created, an activity id is returned.
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Image are limited by size, be sure to pass only small images (you can use ```resizeFactor```).
   ///
   /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
-  /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
-  /// iOS 16.2+ and does nothing on on iOS 16.2
+  /// is less than 1 minute then no staleDate will be used.
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
@@ -41,14 +40,13 @@ class LiveActivities {
     );
   }
 
-  /// Update an iOS 16.2+ live activity.
+  /// Update a live activity.
   /// You can get an activity id by calling [createActivity].
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Map is limited to String keys and values for now.
   ///
   /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
-  /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
-  /// iOS 16.2+ and does nothing on on iOS 16.2
+  /// is less than 1 minute then no staleDate will be used.
   Future updateActivity(String activityId, Map<String, dynamic> data,
       {Duration? staleIn, AlertConfig? alertConfig}) async {
     await _appGroupsImageService.sendImageToAppGroups(data);
@@ -56,7 +54,7 @@ class LiveActivities {
         alertConfig: alertConfig, staleIn: staleIn);
   }
 
-  /// End an iOS 16.2+ live activity.
+  /// End a live activity.
   /// You can get an activity id by calling [createActivity].
   Future endActivity(String activityId) {
     return LiveActivitiesPlatform.instance.endActivity(activityId);
@@ -74,18 +72,18 @@ class LiveActivities {
     return LiveActivitiesPlatform.instance.getPushToken(activityId);
   }
 
-  /// Get all iOS 16.2+ live activity ids.
+  /// Get all live activity ids.
   /// You can get an activity id by calling [createActivity].
   Future<List<String>> getAllActivitiesIds() {
     return LiveActivitiesPlatform.instance.getAllActivitiesIds();
   }
 
-  /// End all iOS 16.2+ live activities.
+  /// End all live activities.
   Future endAllActivities() {
     return LiveActivitiesPlatform.instance.endAllActivities();
   }
 
-  /// Check if iOS 16.2+ live activities are enabled.
+  /// Check if live activities are enabled.
   Future<bool> areActivitiesEnabled() async {
     return LiveActivitiesPlatform.instance.areActivitiesEnabled();
   }

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -20,14 +20,14 @@ class LiveActivities {
     );
   }
 
-  /// Create an iOS 16.1+ live activity.
+  /// Create an iOS 16.2+ live activity.
   /// When the activity is created, an activity id is returned.
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Image are limited by size, be sure to pass only small images (you can use ```resizeFactor```).
   ///
   /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
   /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
-  /// iOS 16.2+ and does nothing on on iOS 16.1
+  /// iOS 16.2+ and does nothing on on iOS 16.2
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
@@ -41,25 +41,22 @@ class LiveActivities {
     );
   }
 
-  /// Update an iOS 16.1+ live activity.
+  /// Update an iOS 16.2+ live activity.
   /// You can get an activity id by calling [createActivity].
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Map is limited to String keys and values for now.
-  /// 
+  ///
   /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
   /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
-  /// iOS 16.2+ and does nothing on on iOS 16.1
-  Future updateActivity(
-    String activityId, 
-    Map<String, dynamic> data,{
-      Duration? staleIn,
-      AlertConfig? alertConfig}) async {
+  /// iOS 16.2+ and does nothing on on iOS 16.2
+  Future updateActivity(String activityId, Map<String, dynamic> data,
+      {Duration? staleIn, AlertConfig? alertConfig}) async {
     await _appGroupsImageService.sendImageToAppGroups(data);
-    return LiveActivitiesPlatform.instance
-        .updateActivity(activityId, data, alertConfig: alertConfig, staleIn: staleIn);
+    return LiveActivitiesPlatform.instance.updateActivity(activityId, data,
+        alertConfig: alertConfig, staleIn: staleIn);
   }
 
-  /// End an iOS 16.1+ live activity.
+  /// End an iOS 16.2+ live activity.
   /// You can get an activity id by calling [createActivity].
   Future endActivity(String activityId) {
     return LiveActivitiesPlatform.instance.endActivity(activityId);
@@ -77,18 +74,18 @@ class LiveActivities {
     return LiveActivitiesPlatform.instance.getPushToken(activityId);
   }
 
-  /// Get all iOS 16.1+ live activity ids.
+  /// Get all iOS 16.2+ live activity ids.
   /// You can get an activity id by calling [createActivity].
   Future<List<String>> getAllActivitiesIds() {
     return LiveActivitiesPlatform.instance.getAllActivitiesIds();
   }
 
-  /// End all iOS 16.1+ live activities.
+  /// End all iOS 16.2+ live activities.
   Future endAllActivities() {
     return LiveActivitiesPlatform.instance.endAllActivities();
   }
 
-  /// Check if iOS 16.1+ live activities are enabled.
+  /// Check if iOS 16.2+ live activities are enabled.
   Future<bool> areActivitiesEnabled() async {
     return LiveActivitiesPlatform.instance.areActivitiesEnabled();
   }

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -45,11 +45,18 @@ class LiveActivities {
   /// You can get an activity id by calling [createActivity].
   /// Data is a map of key/value pairs that will be transmitted to your iOS extension widget.
   /// Map is limited to String keys and values for now.
-  Future updateActivity(String activityId, Map<String, dynamic> data,
-      [AlertConfig? alertConfig]) async {
+  /// 
+  /// [StaleIn] indicates if a StaleDate should be added to the activity. If the value is null or the Duration
+  /// is less than 1 minute then no staleDate will be used. The parameter only affects the live activity on
+  /// iOS 16.2+ and does nothing on on iOS 16.1
+  Future updateActivity(
+    String activityId, 
+    Map<String, dynamic> data,{
+      Duration? staleIn,
+      AlertConfig? alertConfig}) async {
     await _appGroupsImageService.sendImageToAppGroups(data);
     return LiveActivitiesPlatform.instance
-        .updateActivity(activityId, data, alertConfig);
+        .updateActivity(activityId, data, alertConfig: alertConfig, staleIn: staleIn);
   }
 
   /// End an iOS 16.1+ live activity.

--- a/lib/live_activities_method_channel.dart
+++ b/lib/live_activities_method_channel.dart
@@ -31,29 +31,32 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
     });
   }
 
+  // If the duration is less than 1 minute then pass a null value instead of using 0 minutes
+  int? getStaleInMinutes(Duration? staleIn) {
+    return (staleIn?.inMinutes ?? 0) >= 1 ? staleIn?.inMinutes : null;
+  }
+
   @override
   Future<String?> createActivity(
     Map<String, dynamic> data, {
     bool removeWhenAppIsKilled = false,
     Duration? staleIn,
   }) async {
-    // If the duration is less than 1 minute then pass a null value instead of using 0 minutes
-    final staleInMinutes =
-        (staleIn?.inMinutes ?? 0) >= 1 ? staleIn?.inMinutes : null;
     return methodChannel.invokeMethod<String>('createActivity', {
       'data': data,
       'removeWhenAppIsKilled': removeWhenAppIsKilled,
-      'staleIn': staleInMinutes,
+      'staleIn': getStaleInMinutes(staleIn),
     });
   }
 
   @override
   Future updateActivity(String activityId, Map<String, dynamic> data,
-      [AlertConfig? alertConfig]) async {
+      {Duration? staleIn, AlertConfig? alertConfig}) async {
     return methodChannel.invokeMethod('updateActivity', {
       'activityId': activityId,
       'data': data,
-      'alertConfig': alertConfig?.toMap()
+      'alertConfig': alertConfig?.toMap(),
+      'staleIn': getStaleInMinutes(staleIn),
     });
   }
 

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -42,7 +42,7 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
   }
 
   Future updateActivity(String activityId, Map<String, dynamic> data,
-      [AlertConfig? alertConfig]) {
+      {Duration? staleIn, AlertConfig? alertConfig}) {
     throw UnimplementedError('updateActivity() has not been implemented.');
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: live_activities
-description: A Flutter plugin to use iOS 16.1+ Live Activities & iPhone 14 Pro Dynamic Island features
+description: A Flutter plugin to use iOS 16.2+ Live Activities & iPhone 14 Pro Dynamic Island features
 version: 1.9.1+1
 homepage: https://dimitridessus.fr/
 repository: https://github.com/istornz/live_activities

--- a/test/live_activities_test.dart
+++ b/test/live_activities_test.dart
@@ -79,8 +79,11 @@ class MockLiveActivitiesPlatform
   }
 
   @override
-  Future updateActivity(String activityId, Map<String, dynamic> data,
-      [AlertConfig? alertConfig]) {
+  Future updateActivity(
+    String activityId, 
+    Map<String, dynamic> data,{
+      Duration? staleIn,
+      AlertConfig? alertConfig}) {
     return Future.value();
   }
 }


### PR DESCRIPTION
Update "update" function to match Apple's updated method, including supporting staleIn time same as in createActivity.

[The previous method has been deprecated](https://developer.apple.com/documentation/activitykit/activity/update(using:))

NOTE: this new "update" function requires iOS version 16.2, not 16.1. I replaced all of the 16.1's with 16.2, but I don't know if that's what you'll want for the package. My need definitely doesn't cover supporting users who insist on being on 16.1.

(Thanks for making this easy for us, Apple, lol)