### PR TITLE
Fixes background thread invocation of event streams

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+8"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -86,46 +78,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_image_compress:
-    dependency: transitive
-    description:
-      name: flutter_image_compress
-      sha256: f159d2e8c4ed04b8e36994124fd4a5017a0f01e831ae3358c74095c340e9ae5e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
-  flutter_image_compress_common:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_common
-      sha256: "7cad12802628706655920089cfe9ee1d1098300e7f39a079eb160458bbc47652"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  flutter_image_compress_macos:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_macos
-      sha256: fea1e3d71150d03373916b832c49b5c2f56c3e7e13da82a929274a2c6f88251e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
-  flutter_image_compress_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_platform_interface
-      sha256: eb4f055138b29b04498ebcb6d569aaaee34b64d75fb74ea0d40f9790bf47ee9d
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  flutter_image_compress_web:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_web
-      sha256: da41cc3859f19d11c7d10be615f6a9dcf0907e7daffde7442bf4cc2486663660
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3+2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -147,19 +99,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -174,39 +137,39 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.1"
+    version: "1.9.1+1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -332,14 +295,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
   win32:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -383,20 +383,30 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   private func monitorLiveActivity<T : ActivityAttributes>(_ activity: Activity<T>) {
     Task {
       for await state in activity.activityStateUpdates {
-        var response: Dictionary<String, Any> = Dictionary()
-        response["activityId"] = activity.id
         switch state {
         case .active:
           monitorTokenChanges(activity)
         case .dismissed, .ended:
-          response["status"] = "ended"
-          activityEventSink?.self(response)
+          DispatchQueue.main.async {
+              var response: Dictionary<String, Any> = Dictionary()
+              response["activityId"] = activity.id
+              response["status"] = "ended"
+              self.activityEventSink?.self(response)
+          }
         case .stale:
-          response["status"] = "stale"
-          activityEventSink?.self(response)
+          DispatchQueue.main.async {
+              var response: Dictionary<String, Any> = Dictionary()
+              response["activityId"] = activity.id
+              response["status"] = "stale"
+              self.activityEventSink?.self(response)
+          }
         @unknown default:
-          response["status"] = "unknown"
-          activityEventSink?.self(response)
+          DispatchQueue.main.async {
+              var response: Dictionary<String, Any> = Dictionary()
+              response["activityId"] = activity.id
+              response["status"] = "unknown"
+              self.activityEventSink?.self(response)
+          }
         }
       }
     }
@@ -406,12 +416,14 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   private func monitorTokenChanges<T: ActivityAttributes>(_ activity: Activity<T>) {
     Task {
       for await data in activity.pushTokenUpdates {
-        var response: Dictionary<String, Any> = Dictionary()
-        let pushToken = data.map {String(format: "%02x", $0)}.joined()
-        response["token"] = pushToken
-        response["activityId"] = activity.id
-        response["status"] = "active"
-        activityEventSink?.self(response)
+        DispatchQueue.main.async {
+          var response: Dictionary<String, Any> = Dictionary()
+          let pushToken = data.map {String(format: "%02x", $0)}.joined()
+          response["token"] = pushToken
+          response["activityId"] = activity.id
+          response["status"] = "active"
+          self.activityEventSink?.self(response)
+        }
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.1.6
   app_group_directory: ^2.0.0
-  flutter_image_compress: ^2.0.4
   path_provider: ^2.1.1
   flutter_native_image: ^0.0.6+1
 


### PR DESCRIPTION
I'm facing the following issue in production app:

`[ERROR:flutter/shell/common/shell.cc(1038)] The 'live_activities/activity_status' channel sent a message from native to Flutter on a non-platform thread. Platform channel messages must be sent on the platform thread. Failure to do so may result in data loss or crashes, and must be fixed in the plugin or application code creating that channel.`

I'm not sure which invocation of the stream is causing this, but just in case I added main thread execution wrapping all invocations of the method. Let me know if you disagree.

* Also removed an unused dependency