### PR TITLE
Fixed: The 'live_activities' channel sent a message from native to Flutter on a non-platform thread 

### DIFF
--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -47,8 +47,10 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
                               print("Activity PushToStart Token: \(token)")
                               //send this token to your notification server
 
-                              // PushToken über den Flutter Channel senden
-                              channel.invokeMethod("onPushTokenReceived", arguments: token)
+                              DispatchQueue.main.async {
+                                  // PushToken über den Flutter Channel senden
+                                  channel.invokeMethod("onPushTokenReceived", arguments: token)
+                              }
                       }
 
                   for await activity in Activity<LiveActivitiesAppAttributes>.activityUpdates {


### PR DESCRIPTION
#96 

As per the flutter documentation we should wrap invokeMethods with the following block. This was causing the warning.
[Documentation](https://docs.flutter.dev/platform-integration/platform-channels#jumping-to-the-main-thread-in-ios)