### PR TITLE
Update live_activity_file.dart

### DIFF
--- a/lib/models/live_activity_file.dart
+++ b/lib/models/live_activity_file.dart
@@ -118,5 +118,5 @@ class LiveActivityFileFromMemory extends LiveActivityFile {
   }
 
   @override
-  String get fileName => throw UnimplementedError();
+  String get fileName => imageName;
 }


### PR DESCRIPTION
Else LiveActivityFileFromMemory can't share image with appGroup.

https://github.com/istornz/flutter_live_activities/blob/a9128db21dbb82320b1111fe9f4c979a9d691fb2/lib/services/app_groups_file_service.dart#L43