### PR TITLE
✨Ability to get the "pushToStartToken"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ You need to **implement** in your Flutter iOS project a **Widget Extension** & d
 > ℹ️ You can check into the [**example repository**](https://github.com/istornz/live_activities/tree/main/example) for a full example app using Live Activities & Dynamic Island
 
 - ## 📱 Native
-    - Open the Xcode workspace project `ios/Runner.xcworkspace`.
-    - Click on `File` -> `New` -> `Target...`
-        - Select `Widget Extension` & click on **Next**.
+  - Open the Xcode workspace project `ios/Runner.xcworkspace`.
+  - Click on `File` -> `New` -> `Target...`
+    - Select `Widget Extension` & click on **Next**.
     - Specify the product name (e.g., `MyAppWidget`) and be sure to select "**Runner**" in "Embed in Application" dropdown.
-        - Click on **Finish**.
-        - When selecting Finish, an alert will appear, you will need to click on **Activate**.
+    - Click on **Finish**.
+    - When selecting Finish, an alert will appear, you will need to click on **Activate**.
 
 <img alt="create widget extension xcode" src="https://raw.githubusercontent.com/istornz/live_activities/main/images/tutorial/create_widget_extension.webp" width="700px" />
 
@@ -124,20 +124,20 @@ struct FootballMatchApp: Widget {
 
 - ## 💙 Flutter
 
-    - Import the plugin.
+  - Import the plugin.
 
   ```dart
   import 'package:live_activities/live_activities.dart';
   ```
 
-    - Initialize the Plugin by passing the created **App Group Id** (created above).
+  - Initialize the Plugin by passing the created **App Group Id** (created above).
 
   ```dart
   final _liveActivitiesPlugin = LiveActivities();
   _liveActivitiesPlugin.init(appGroupId: "YOUR_GROUP_ID");
   ```
 
-    - Create your dynamic activity.
+  - Create your dynamic activity.
 
   ```dart
   final Map<String, dynamic> activityModel = {
@@ -183,10 +183,10 @@ final Map<String, dynamic> activityModel = {
   'txtFile': LiveActivityFileFromAsset('assets/files/rules.txt'),
   'assetKey': LiveActivityFileFromAsset.image('assets/images/pizza_chorizo.png'),
   'url': LiveActivityFileFromUrl.image(
-      'https://cdn.pixabay.com/photo/2015/10/01/17/17/car-967387__480.png',
-      imageOptions: LiveActivityImageFileOptions(
-          resizeFactor: 0.2
-      )
+    'https://cdn.pixabay.com/photo/2015/10/01/17/17/car-967387__480.png',
+    imageOptions: LiveActivityImageFileOptions(
+      resizeFactor: 0.2
+    )
   ),
 };
 
@@ -270,24 +270,24 @@ You can update live activity directly in your app using the `updateActivity()` m
 To do this, you can update it using Push Notification on a server.
 
 - Get the push token:
-    - Listen on the activity updates (recommended):
-      ```dart
-      _liveActivitiesPlugin.activityUpdateStream.listen((event) {
-        event.map(
-          active: (activity) {
-            // Get the token
-            print(activity.activityToken);
-          },
-          ended: (activity) {},
-          unknown: (activity) {},
-        );
-      });
-      ```
-    - Get directly the push token (not recommended, because the token may change in the future):
-      ```dart
-      final activityToken = await _liveActivitiesPlugin.getPushToken(_latestActivityId!);
-      print(activityToken);
-      ```
+  - Listen on the activity updates (recommended):
+    ```dart
+    _liveActivitiesPlugin.activityUpdateStream.listen((event) {
+      event.map(
+        active: (activity) {
+          // Get the token
+          print(activity.activityToken);
+        },
+        ended: (activity) {},
+        unknown: (activity) {},
+      );
+    });
+    ```
+  - Get directly the push token (not recommended, because the token may change in the future):
+    ```dart
+    final activityToken = await _liveActivitiesPlugin.getPushToken(_latestActivityId!);
+    print(activityToken);
+    ```
 - Update your activity with the token on your server (more information can be [**found here**](https://ohdarling88.medium.com/update-dynamic-island-and-live-activity-with-push-notification-38779803c145)).
 
 To set `matchName` for a specific notification, you just need to grab the notification id you want (ex. `35253464632`) and concatenate with your key by adding a `_`, example: `35253464632_matchName`.
@@ -418,12 +418,12 @@ server needs to use Apple's APNs with the appropriate authentication to deliver 
 > - Supports Live Activities: Be sure to set the `NSSupportsLiveActivities` property to `true` in `Info.plist` files for **BOTH** `Runner` and your `extension`.
 > - iOS Version Requirement: The device must run **iOS 16.1 or later**.
 > - Device Activity Check: Confirm that the `areActivitiesEnabled()` method returns true on your device.
-> - Minimum Deployment Target: Confirm that the `extensions` deployment target is not set lower than your devices.
+> - Minimum Deployment Target: Confirm that the `extensions` deployment target is not set lower than your devices. 
 
 ### Is Android supported?
 
 > Currently, no, but the plugin does not crash when run on Android. This means you can safely install it in a hybrid app.
->
+> 
 > Simply call `areActivitiesEnabled()` before creating your activity to ensure it can be displayed on the user's device. 😊
 
 ## 👥 Contributions

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ You need to **implement** in your Flutter iOS project a **Widget Extension** & d
 > ℹ️ You can check into the [**example repository**](https://github.com/istornz/live_activities/tree/main/example) for a full example app using Live Activities & Dynamic Island
 
 - ## 📱 Native
-  - Open the Xcode workspace project `ios/Runner.xcworkspace`.
-  - Click on `File` -> `New` -> `Target...`
-    - Select `Widget Extension` & click on **Next**.
+    - Open the Xcode workspace project `ios/Runner.xcworkspace`.
+    - Click on `File` -> `New` -> `Target...`
+        - Select `Widget Extension` & click on **Next**.
     - Specify the product name (e.g., `MyAppWidget`) and be sure to select "**Runner**" in "Embed in Application" dropdown.
-    - Click on **Finish**.
-    - When selecting Finish, an alert will appear, you will need to click on **Activate**.
+        - Click on **Finish**.
+        - When selecting Finish, an alert will appear, you will need to click on **Activate**.
 
 <img alt="create widget extension xcode" src="https://raw.githubusercontent.com/istornz/live_activities/main/images/tutorial/create_widget_extension.webp" width="700px" />
 
@@ -124,20 +124,20 @@ struct FootballMatchApp: Widget {
 
 - ## 💙 Flutter
 
-  - Import the plugin.
+    - Import the plugin.
 
   ```dart
   import 'package:live_activities/live_activities.dart';
   ```
 
-  - Initialize the Plugin by passing the created **App Group Id** (created above).
+    - Initialize the Plugin by passing the created **App Group Id** (created above).
 
   ```dart
   final _liveActivitiesPlugin = LiveActivities();
   _liveActivitiesPlugin.init(appGroupId: "YOUR_GROUP_ID");
   ```
 
-  - Create your dynamic activity.
+    - Create your dynamic activity.
 
   ```dart
   final Map<String, dynamic> activityModel = {
@@ -183,10 +183,10 @@ final Map<String, dynamic> activityModel = {
   'txtFile': LiveActivityFileFromAsset('assets/files/rules.txt'),
   'assetKey': LiveActivityFileFromAsset.image('assets/images/pizza_chorizo.png'),
   'url': LiveActivityFileFromUrl.image(
-    'https://cdn.pixabay.com/photo/2015/10/01/17/17/car-967387__480.png',
-    imageOptions: LiveActivityImageFileOptions(
-      resizeFactor: 0.2
-    )
+      'https://cdn.pixabay.com/photo/2015/10/01/17/17/car-967387__480.png',
+      imageOptions: LiveActivityImageFileOptions(
+          resizeFactor: 0.2
+      )
   ),
 };
 
@@ -270,24 +270,24 @@ You can update live activity directly in your app using the `updateActivity()` m
 To do this, you can update it using Push Notification on a server.
 
 - Get the push token:
-  - Listen on the activity updates (recommended):
-    ```dart
-    _liveActivitiesPlugin.activityUpdateStream.listen((event) {
-      event.map(
-        active: (activity) {
-          // Get the token
-          print(activity.activityToken);
-        },
-        ended: (activity) {},
-        unknown: (activity) {},
-      );
-    });
-    ```
-  - Get directly the push token (not recommended, because the token may change in the future):
-    ```dart
-    final activityToken = await _liveActivitiesPlugin.getPushToken(_latestActivityId!);
-    print(activityToken);
-    ```
+    - Listen on the activity updates (recommended):
+      ```dart
+      _liveActivitiesPlugin.activityUpdateStream.listen((event) {
+        event.map(
+          active: (activity) {
+            // Get the token
+            print(activity.activityToken);
+          },
+          ended: (activity) {},
+          unknown: (activity) {},
+        );
+      });
+      ```
+    - Get directly the push token (not recommended, because the token may change in the future):
+      ```dart
+      final activityToken = await _liveActivitiesPlugin.getPushToken(_latestActivityId!);
+      print(activityToken);
+      ```
 - Update your activity with the token on your server (more information can be [**found here**](https://ohdarling88.medium.com/update-dynamic-island-and-live-activity-with-push-notification-38779803c145)).
 
 To set `matchName` for a specific notification, you just need to grab the notification id you want (ex. `35253464632`) and concatenate with your key by adding a `_`, example: `35253464632_matchName`.
@@ -296,24 +296,100 @@ That's it 😇
 
 <br />
 
+## Push-to-Start Live Activities (iOS 17.2+) 🚀
+
+iOS 17.2 introduces the ability
+to [create Live Activities remotely](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Start-new-Live-Activities-with-ActivityKit-push-notifications)
+via push notifications before the user has even
+opened your app. This is called "push-to-start" functionality.
+
+### Check Support
+
+First, check if the device supports push-to-start:
+
+```dart
+
+final isPushToStartSupported = await _liveActivitiesPlugin.allowsPushStart();
+if (isPushToStartSupported) {
+  // Device supports push-to-start (iOS 17.2+)
+}
+```
+
+### Listen for Push-to-Start Tokens
+
+To use push-to-start, you need to listen for push-to-start tokens:
+
+```dart
+_liveActivitiesPlugin.pushToStartTokenUpdateStream.listen((token) {
+  // Send this token to your server
+  print('Received push-to-start token: $token');
+    
+  // Your server can use this token to create a Live Activity
+  // without the user having to open your app first
+});
+```
+
+### Server Implementation
+
+On your server, you'll need to send a push notification with the following
+payload [structure](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity):
+
+```json
+{
+  "aps": {
+    "timestamp": 1234,
+    "event": "start",
+    "content-state": {
+      "currentHealthLevel": 100,
+      "eventDescription": "Adventure has begun!"
+    },
+    "attributes-type": "AdventureAttributes",
+    "attributes": {
+      "currentHealthLevel": 100,
+      "eventDescription": "Adventure has begun!"
+    },
+    "alert": {
+      "title": {
+        "loc-key": "%@ is on an adventure!",
+        "loc-args": [
+          "Power Panda"
+        ]
+      },
+      "body": {
+        "loc-key": "%@ found a sword!",
+        "loc-args": [
+          "Power Panda"
+        ]
+      },
+      "sound": "chime.aiff"
+    }
+  }
+}
+```
+
+The push notification should be sent to the push-to-start token you received from the pushToStartTokenUpdateStream. Your
+server needs to use Apple's APNs with the appropriate authentication to deliver these notifications.
+
 ## 📘 Documentation
 
-| Name                        | Description                                                                                                                                 | Returned value                                                                                             |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `.init()`                   | Initialize the Plugin by providing an App Group Id (see above)                                                                              | `Future` When the plugin is ready to create/update an activity                                             |
-| `.createActivity()`         | Create an iOS live activity                                                                                                                 | `String` The activity identifier                                                                           |
-| `.createOrUpdateActivity()` | Create or updates an (existing) live activity based on the provided `UUID` via `customId`                                                   | `String` The activity identifier                                                                           |
-| `.updateActivity()`         | Update the live activity data by using the `activityId` provided                                                                            | `Future` When the activity was updated                                                                     |
-| `.endActivity()`            | End the live activity by using the `activityId` provided                                                                                    | `Future` When the activity was ended                                                                       |
-| `.getAllActivitiesIds()`    | Get all activities ids created                                                                                                              | `Future<List<String>>` List of all activities ids                                                          |
-| `.getAllActivities()`       | Get a Map of activitiyIds and the `ActivityState`                                                                                           | `Future<Map<String, LiveActivityState>>` Map of all activitiyId -> `LiveActivityState`                     |
-| `.endAllActivities()`       | End all live activities of the app                                                                                                          | `Future` When all activities was ended                                                                     |
-| `.areActivitiesEnabled()`   | Check if live activities feature are supported & enabled                                                                                    | `Future<bool>` Live activities supported or not                                                            |
-| `.getActivityState()`       | Get the activity current state                                                                                                              | `Future<LiveActivityState?>` An enum to know the status of the activity (`active`, `dismissed` or `ended`) |
-| `.getPushToken()`           | Get the activity push token synchronously (prefer using `activityUpdateStream` instead to keep push token up to date)                       | `String?` The activity push token (can be null)                                                            |
-| `.urlSchemeStream()`        | Subscription to handle every url scheme (ex: when the app is opened from a live activity / dynamic island button, you can pass data)        | `Future<UrlSchemeData>` Url scheme data which handle `scheme` `url` `host` `path` `queryItems`             |
-| `.dispose()`                | Remove all pictures passed in the AppGroups directory in the current session, you can use the `force` parameters to remove **all** pictures | `Future` Picture removed                                                                                   |
-| `.activityUpdateStream`     | Get notified with a stream about live activity push token & status                                                                          | `Stream<ActivityUpdate>` Status updates for new push tokens or when the activity ends                      |
+| Name                            | Description                                                                                                                                 | Returned value                                                                                             |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `.init()`                       | Initialize the Plugin by providing an App Group Id (see above)                                                                              | `Future` When the plugin is ready to create/update an activity                                             |
+| `.createActivity()`             | Create an iOS live activity                                                                                                                 | `String` The activity identifier                                                                           |
+| `.createOrUpdateActivity()`     | Create or updates an (existing) live activity based on the provided `UUID` via `customId`                                                   | `String` The activity identifier                                                                           |
+| `.updateActivity()`             | Update the live activity data by using the `activityId` provided                                                                            | `Future` When the activity was updated                                                                     |
+| `.endActivity()`                | End the live activity by using the `activityId` provided                                                                                    | `Future` When the activity was ended                                                                       |
+| `.getAllActivitiesIds()`        | Get all activities ids created                                                                                                              | `Future<List<String>>` List of all activities ids                                                          |
+| `.getAllActivities()`           | Get a Map of activitiyIds and the `ActivityState`                                                                                           | `Future<Map<String, LiveActivityState>>` Map of all activitiyId -> `LiveActivityState`                     |
+| `.endAllActivities()`           | End all live activities of the app                                                                                                          | `Future` When all activities was ended                                                                     |
+| `.areActivitiesEnabled()`       | Check if live activities feature are supported & enabled                                                                                    | `Future<bool>` Live activities supported or not                                                            |
+| `.allowsPushStart()`            | Check if device supports push-to-start for Live Activities (iOS 17.2+)                                                                      | `Future<bool>` Whether push-to-start is supported                                                          |
+| `.getActivityState()`           | Get the activity current state                                                                                                              | `Future<LiveActivityState?>` An enum to know the status of the activity (`active`, `dismissed` or `ended`) |
+| `.getPushToken()`               | Get the activity push token synchronously (prefer using `activityUpdateStream` instead to keep push token up to date)                       | `String?` The activity push token (can be null)                                                            |
+| `.urlSchemeStream()`            | Subscription to handle every url scheme (ex: when the app is opened from a live activity / dynamic island button, you can pass data)        | `Future<UrlSchemeData>` Url scheme data which handle `scheme` `url` `host` `path` `queryItems`             |
+| `.dispose()`                    | Remove all pictures passed in the AppGroups directory in the current session, you can use the `force` parameters to remove **all** pictures | `Future` Picture removed                                                                                   |
+| `.activityUpdateStream`         | Get notified with a stream about live activity push token & status                                                                          | `Stream<ActivityUpdate>` Status updates for new push tokens or when the activity ends                      |
+| `.pushToStartTokenUpdateStream` | Stream of push-to-start tokens for creating Live Activities remotely (iOS 17.2+)                                                            | `Stream<String>` Stream of tokens for push-to-start capability                                             |
 
 <br />
 
@@ -342,12 +418,12 @@ That's it 😇
 > - Supports Live Activities: Be sure to set the `NSSupportsLiveActivities` property to `true` in `Info.plist` files for **BOTH** `Runner` and your `extension`.
 > - iOS Version Requirement: The device must run **iOS 16.1 or later**.
 > - Device Activity Check: Confirm that the `areActivitiesEnabled()` method returns true on your device.
-> - Minimum Deployment Target: Confirm that the `extensions` deployment target is not set lower than your devices. 
+> - Minimum Deployment Target: Confirm that the `extensions` deployment target is not set lower than your devices.
 
 ### Is Android supported?
 
 > Currently, no, but the plugin does not crash when run on Android. This means you can safely install it in a hybrid app.
-> 
+>
 > Simply call `areActivitiesEnabled()` before creating your activity to ensure it can be displayed on the user's device. 😊
 
 ## 👥 Contributions

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -105,6 +105,11 @@ class LiveActivities {
     return LiveActivitiesPlatform.instance.areActivitiesEnabled();
   }
 
+  /// Checks if iOS 17.2+ which allows push start for live activities.
+  Future<bool> allowsPushStart() {
+    return LiveActivitiesPlatform.instance.allowsPushStart();
+  }
+
   /// Get a stream of url scheme data.
   /// Don't forget to add **CFBundleURLSchemes** to your Info.plist file.
   /// Return a Future of [scheme] [url] [host] [path] and [queryParameters].
@@ -147,4 +152,29 @@ class LiveActivities {
   /// ```
   Stream<ActivityUpdate> get activityUpdateStream =>
       LiveActivitiesPlatform.instance.activityUpdateStream;
+
+  /// A stream of push-to-start tokens for iOS 17.2+ Live Activities.
+  /// This stream emits tokens that can be used to start a Live Activity remotely via push notifications.
+  ///
+  /// When iOS generates or updates a push-to-start token, it will be emitted through this stream.
+  /// You should send this token to your push notification server to enable remote Live Activity creation.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// liveActivities.pushToStartTokenUpdateStream.listen((token) {
+  ///   // Send token to your server
+  ///   print('Received push-to-start token: $token');
+  /// });
+  /// ```
+  ///
+  /// This feature is only available on iOS 17.2 and later. Use [allowsPushStart] to check support.
+  Stream<String> get pushToStartTokenUpdateStream  async* {
+    final allowed = await allowsPushStart();
+
+    if (!allowed) {
+      throw Exception('Push-to-start is not allowed on this device');
+    }
+
+    yield* LiveActivitiesPlatform.instance.pushToStartTokenUpdateStream;
+  }
 }

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -77,6 +77,11 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
         'areActivitiesEnabled() has not been implemented.');
   }
 
+  Future<bool> allowsPushStart() {
+    throw UnimplementedError(
+        'supportsStartActivities() has not been implemented.');
+  }
+
   Stream<UrlSchemeData> urlSchemeStream() {
     throw UnimplementedError('urlSchemeStream() has not been implemented.');
   }
@@ -91,4 +96,7 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
 
   Stream<ActivityUpdate> get activityUpdateStream =>
       throw UnimplementedError('pushTokenUpdates has not been implemented');
+
+  Stream<String> get pushToStartTokenUpdateStream =>
+      throw UnimplementedError('pushToStartTokenUpdateStream has not been implemented');
 }

--- a/test/live_activities_test.dart
+++ b/test/live_activities_test.dart
@@ -98,6 +98,16 @@ class MockLiveActivitiesPlatform
   }) {
     return Future.value();
   }
+
+  @override
+  Future<bool> allowsPushStart() {
+    return Future.value(true);
+  }
+
+  @override
+  Stream<String> get pushToStartTokenUpdateStream {
+    return Stream.value('PUSH_TO_START_TOKEN');
+  }
 }
 
 void main() {
@@ -189,5 +199,16 @@ void main() {
         result.mapOrNull(active: (state) => state.activityToken);
 
     expect(correctMappingNotNull, 'ACTIVITY_TOKEN');
+  });
+
+  test('allowsPushStart', () async {
+    expect(await liveActivitiesPlugin.allowsPushStart(), true);
+  });
+
+  test('pushToStartTokenUpdateStream', () async {
+    expect(
+      await liveActivitiesPlugin.pushToStartTokenUpdateStream.first,
+      'PUSH_TO_START_TOKEN',
+    );
   });
 }


### PR DESCRIPTION
This pull request introduces the "push-to-start" functionality for Live Activities in iOS 17.2, allowing Live Activities to be created remotely via push notifications. The changes include updates to the README documentation, iOS plugin implementation, and Dart interfaces to support this new feature.

### Documentation Updates:
* Added a new section in `README.md` explaining how to use the push-to-start feature, including checking device support, listening for push-to-start tokens, and server implementation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R299-R376) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R386-R392)

### iOS Plugin Implementation:
* Updated `LiveActivitiesPlugin.swift` to include a new event channel for push-to-start token updates and methods to handle push-to-start functionality. [[1]](diffhunk://#diff-eebf1fb58a14c440b45fe6e2a306839e99636203eee957bbbcf131ef081e18d9R29-R49) [[2]](diffhunk://#diff-eebf1fb58a14c440b45fe6e2a306839e99636203eee957bbbcf131ef081e18d9R58-R60) [[3]](diffhunk://#diff-eebf1fb58a14c440b45fe6e2a306839e99636203eee957bbbcf131ef081e18d9R73-R74) [[4]](diffhunk://#diff-eebf1fb58a14c440b45fe6e2a306839e99636203eee957bbbcf131ef081e18d9R97-R107) [[5]](diffhunk://#diff-eebf1fb58a14c440b45fe6e2a306839e99636203eee957bbbcf131ef081e18d9R384-R398)

### Dart Interface Updates:
* Added `allowsPushStart()` method and `pushToStartTokenUpdateStream` in `lib/live_activities.dart` to check for push-to-start support and listen for push-to-start tokens. [[1]](diffhunk://#diff-92cb7a6d9c2018f44cf56d10ee7455e87962dd6bd3c994ad129a0c8f599017cbR108-R112) [[2]](diffhunk://#diff-92cb7a6d9c2018f44cf56d10ee7455e87962dd6bd3c994ad129a0c8f599017cbR155-R179)
* Updated `lib/live_activities_method_channel.dart` to implement the new methods and event channels for push-to-start functionality. [[1]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL20-R26) [[2]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL42-R43) [[3]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL52-R54) [[4]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL68-R64) [[5]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL92-R95) [[6]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfL113-R122) [[7]](diffhunk://#diff-6af30bdca5205b5d600963df9cf4a5d545c934382a22a6667e6cd09ab8c2a0dfR153-R156)
* Updated `lib/live_activities_platform_interface.dart` to include abstract methods for push-to-start support. [[1]](diffhunk://#diff-e536ffc9730fdcd4ed042000cfb0f1330a3ed8ac62119623c5f5bad9f5b8711fR80-R84) [[2]](diffhunk://#diff-e536ffc9730fdcd4ed042000cfb0f1330a3ed8ac62119623c5f5bad9f5b8711fR99-R101)

### Testing:
* Updated `test/live_activities_test.dart` to include mock implementations for the new push-to-start methods.