### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 - On both platforms, activityID is now a required parameter for `createActivity` and `createOrUpdateActivity()`.
 - Bump **iOS** minimum version to **13**.
-- Bump **Android** minimum version to **24**.
 
 ## 2.3.2
 * ✨ Ability to get the "pushToStartToken" (thanks to @Clon1998 👍).


### PR DESCRIPTION
Android use flutter.minSdkVersion, I reverted code in my 2.4.0 PR but forgot to revert the changelog part.