### PR TITLE
feat: Add option to control iOS notification permission request

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Link(destination: URL(string: "la://my.app/order?=123")!) { // Replace "la" with
 _liveActivitiesPlugin.init(
   appGroupId: 'your.group.id', // replace here with your custom app group id
   urlScheme: 'str' // replace here with your custom app scheme
+  requireNotificationPermission: true // if set to false, not request notification permission for iOS
 );
 ```
 

--- a/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
+++ b/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
@@ -25,6 +25,7 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
   private var urlSchemeSink: FlutterEventSink?
   private var appGroupId: String?
   private var urlScheme: String?
+  private var requireNotificationPermission: Bool = true
   private var sharedDefault: UserDefaults?
   private var appLifecycleLiveActivityIds = [String]()
   private var activityEventSink: FlutterEventSink?
@@ -133,6 +134,8 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             result(FlutterError(code: "WRONG_ARGS", message: "argument are not valid, check if 'appGroupId' is valid", details: nil))
           }
 
+          self.requireNotificationPermission = args["requireNotificationPermission"] as? Bool ?? true
+
           break
         case "createActivity":
           initializationGuard(result: result)
@@ -234,10 +237,12 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
   
   @available(iOS 16.1, *)
   func createActivity(data: [String: Any], removeWhenAppIsKilled: Bool, staleIn: Int?, activityId: String? = nil, result: @escaping FlutterResult) {
-    let center = UNUserNotificationCenter.current()
-    center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-      if let error = error {
-        result(FlutterError(code: "AUTHORIZATION_ERROR", message: "authorization error", details: error.localizedDescription))
+    if self.requireNotificationPermission {
+      let center = UNUserNotificationCenter.current()
+      center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        if let error = error {
+          result(FlutterError(code: "AUTHORIZATION_ERROR", message: "authorization error", details: error.localizedDescription))
+        }
       }
     }
     

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -14,11 +14,17 @@ class LiveActivities {
   /// Be sure to set the *SAME* App Group in both targets.
   /// [urlScheme] is optional and is the scheme sub-component of the URL.
   /// [appGroupId] is the App Group identifier.
-  Future init({required String appGroupId, String? urlScheme}) {
+  /// If [requireNotificationPermission] is set to false, the plugin will not request notification permission for iOS.
+  Future init({
+    required String appGroupId,
+    String? urlScheme,
+    bool requireNotificationPermission = true,
+  }) {
     _appGroupsFileService.init(appGroupId: appGroupId);
     return LiveActivitiesPlatform.instance.init(
       appGroupId,
       urlScheme: urlScheme,
+      requireNotificationPermission: requireNotificationPermission,
     );
   }
 

--- a/lib/live_activities_method_channel.dart
+++ b/lib/live_activities_method_channel.dart
@@ -27,10 +27,15 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
       const EventChannel('live_activities/push_to_start_token_updates');
 
   @override
-  Future init(String appGroupId, {String? urlScheme}) async {
+  Future init(
+    String appGroupId, {
+    String? urlScheme,
+    bool requireNotificationPermission = true,
+  }) async {
     await methodChannel.invokeMethod('init', {
       'appGroupId': appGroupId,
       'urlScheme': urlScheme,
+      'requireNotificationPermission': requireNotificationPermission
     });
   }
 

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -29,6 +29,7 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
   Future init(
     String appGroupId, {
     String? urlScheme,
+    bool requireNotificationPermission = true,
   }) {
     throw UnimplementedError('init() has not been implemented.');
   }

--- a/test/live_activities_test.dart
+++ b/test/live_activities_test.dart
@@ -12,7 +12,11 @@ class MockLiveActivitiesPlatform
     with MockPlatformInterfaceMixin
     implements LiveActivitiesPlatform {
   @override
-  Future init(String appGroupId, {String? urlScheme}) {
+  Future init(
+    String appGroupId, {
+    String? urlScheme,
+    bool requireNotificationPermission = true,
+  }) {
     return Future.value();
   }
 


### PR DESCRIPTION
This PR adds an option to select whether to request iOS notification permissions.

As mentioned in #68 and #156, notification permissions are not required if Live Activities are updated only with local data. However, the current package implementation requests permission regardless of the use case, resulting in unnecessary permission alerts for users.

By using this option, developers can skip the permission request logic when it is not needed.

To ensure backward compatibility and maintain existing behavior, the default value of `requireNotificationPermission` is set to `true`. Developers who wish to skip the permission request should explicitly set this to `false`.

Note: Since notification permissions are mandatory on Android, this change applies only to iOS.

Resolves #68 Resolves #156