### PR TITLE
fix: observe remote-started live activities on iOS

### DIFF
--- a/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
+++ b/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
@@ -29,6 +29,9 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
     private var appLifecycleLiveActivityIds = [String]()
     private var activityEventSink: FlutterEventSink?
     private var pushToStartTokenEventSink: FlutterEventSink?
+    @MainActor private var monitoredActivityIds = Set<String>()
+    @MainActor private var tokenObservedActivityIds = Set<String>()
+    @MainActor private var observingActivityLifecycle = false
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "live_activities", binaryMessenger: registrar.messenger())
@@ -58,6 +61,7 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                 urlSchemeSink = events
             } else if (args == "activityUpdateStream") {
                 activityEventSink = events
+                startObservingActivities()
             } else if (args == "pushToStartTokenUpdateStream") {
                 pushToStartTokenEventSink = events
                 startObservingPushToStartTokens()
@@ -294,7 +298,9 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             if removeWhenAppIsKilled {
                 appLifecycleLiveActivityIds.append(deliveryActivity!.id)
             }
-            monitorLiveActivity(deliveryActivity!)
+            Task { @MainActor in
+                self.attachObserversIfNeeded(deliveryActivity!)
+            }
             result(deliveryActivity!.id)
         }
     }
@@ -427,6 +433,43 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             }
         }
     }
+
+    private func startObservingActivities() {
+        guard #available(iOS 16.1, *) else {
+            return
+        }
+
+        Task {
+            let existingActivities = await MainActor.run { Activity<LiveActivitiesAppAttributes>.activities }
+            await MainActor.run {
+                for activity in existingActivities {
+                    self.attachObserversIfNeeded(activity)
+                }
+            }
+        }
+
+        if #available(iOS 17.2, *) {
+            Task {
+                let shouldStart = await MainActor.run { () -> Bool in
+                    if self.observingActivityLifecycle {
+                        return false
+                    }
+                    self.observingActivityLifecycle = true
+                    return true
+                }
+
+                guard shouldStart else {
+                    return
+                }
+
+                for await activity in Activity<LiveActivitiesAppAttributes>.activityUpdates {
+                    await MainActor.run {
+                        self.attachObserversIfNeeded(activity)
+                    }
+                }
+            }
+        }
+    }
     
     @available(iOS 16.1, *)
     func getAllActivitiesIds(result: @escaping FlutterResult) {
@@ -519,7 +562,9 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             for await state in activity.activityStateUpdates {
                 switch state {
                 case .active:
-                    monitorTokenChanges(activity)
+                    await MainActor.run {
+                        self.attachTokenObserverIfNeeded(activity)
+                    }
                 case .dismissed, .ended:
                     DispatchQueue.main.async {
                         var response: Dictionary<String, Any> = Dictionary()
@@ -560,6 +605,28 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                 }
             }
         }
+    }
+
+    @available(iOS 16.1, *)
+    @MainActor private func attachObserversIfNeeded(_ activity: Activity<LiveActivitiesAppAttributes>) {
+        if !monitoredActivityIds.contains(activity.id) {
+            monitoredActivityIds.insert(activity.id)
+            monitorLiveActivity(activity)
+        }
+
+        if activity.activityState == .active {
+            attachTokenObserverIfNeeded(activity)
+        }
+    }
+
+    @available(iOS 16.1, *)
+    @MainActor private func attachTokenObserverIfNeeded<T: ActivityAttributes>(_ activity: Activity<T>) {
+        if tokenObservedActivityIds.contains(activity.id) {
+            return
+        }
+
+        tokenObservedActivityIds.insert(activity.id)
+        monitorTokenChanges(activity)
     }
     
     @available(iOS 16.1, *)

--- a/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
+++ b/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
@@ -550,10 +550,46 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
         public typealias LiveDeliveryData = ContentState
         
         public struct ContentState: Codable, Hashable {
-            var appGroupId: String
+            var appGroupId: String?
+
+            init(appGroupId: String? = nil) {
+                self.appGroupId = appGroupId
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: DynamicCodingKeys.self)
+                appGroupId = try container.decodeIfPresent(String.self, forKey: DynamicCodingKeys("appGroupId"))
+            }
         }
         
-        var id = UUID()
+        var id: UUID
+
+        init(id: UUID = UUID()) {
+            self.id = id
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: DynamicCodingKeys.self)
+            id = try container.decodeIfPresent(UUID.self, forKey: DynamicCodingKeys("id")) ?? UUID()
+        }
+    }
+
+    struct DynamicCodingKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+
+        init(_ stringValue: String) {
+            self.stringValue = stringValue
+            intValue = nil
+        }
+
+        init?(stringValue: String) {
+            self.init(stringValue)
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
     }
     
     @available(iOS 16.1, *)
@@ -626,7 +662,28 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
         }
 
         tokenObservedActivityIds.insert(activity.id)
+        emitCurrentTokenIfPresent(activity)
         monitorTokenChanges(activity)
+    }
+
+    @available(iOS 16.1, *)
+    private func emitCurrentTokenIfPresent<T: ActivityAttributes>(_ activity: Activity<T>) {
+        guard let data = activity.pushToken else {
+            return
+        }
+
+        let pushToken = data.map { String(format: "%02x", $0) }.joined()
+        guard !pushToken.isEmpty else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            var response: Dictionary<String, Any> = Dictionary()
+            response["token"] = pushToken
+            response["activityId"] = activity.id
+            response["status"] = "active"
+            self.activityEventSink?.self(response)
+        }
     }
     
     @available(iOS 16.1, *)


### PR DESCRIPTION
### Problem

`activityUpdateStream` currently starts observing `pushTokenUpdates` only for activities created through the plugin's local `createActivity(...)` flow.

When a Live Activity is started remotely with push-to-start, or when an activity already exists before the listener is attached, no observer gets attached to that activity. As a result, the plugin can miss the ActivityKit update token entirely.

### Fix

- start observing activities when `activityUpdateStream` is subscribed
- attach observers to already-existing activities
- start `pushTokenUpdates` immediately for activities that are already active
- deduplicate activity and token observers by activity id

### Result

Remote-started Live Activities can emit their update token through `activityUpdateStream` the same way locally created activities already do.
