### PR TITLE
Add scheduleEnd to dismiss a Live Activity at a future date

### DIFF
--- a/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
+++ b/ios/live_activities/Sources/live_activities/LiveActivitiesPlugin.swift
@@ -27,6 +27,11 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
     private var urlScheme: String?
     private var sharedDefault: UserDefaults?
     private var appLifecycleLiveActivityIds = [String]()
+    // Activities ended with a scheduled dismissal date leave Activity.activities
+    // immediately but stay visible on the Lock Screen until the date. Retain them
+    // (type-erased — stored properties can't carry @available) so a later
+    // endActivity can still force-dismiss the card.
+    private var scheduledDismissalActivities: [String: Any] = [:]
     private var activityEventSink: FlutterEventSink?
     private var pushToStartTokenEventSink: FlutterEventSink?
     @MainActor private var monitoredActivityIds = Set<String>()
@@ -190,6 +195,18 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     endActivity(activityId: activityId, result: result)
                 } else {
                     result(FlutterError(code: "WRONG_ARGS", message: "argument are not valid, check if 'activityId' is valid", details: nil))
+                }
+                break
+            case "scheduleEnd":
+                guard let args = call.arguments as? [String: Any] else {
+                    result(FlutterError(code: "WRONG_ARGS", message: "Unknown data type in argument", details: nil))
+                    return
+                }
+                if let activityId = args["activityId"] as? String,
+                   let endTimestamp = (args["endTimestamp"] as? NSNumber)?.doubleValue {
+                    scheduleEnd(activityId: activityId, endTimestampMs: endTimestamp, result: result)
+                } else {
+                    result(FlutterError(code: "WRONG_ARGS", message: "argument are not valid, check if 'activityId' and 'endTimestamp' are valid", details: nil))
                 }
                 break
             case "getActivityState":
@@ -408,7 +425,32 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             result(nil)
         }
     }
-    
+
+    // Ends the activity now with ActivityKit's `dismissalPolicy: .after(date)`
+    // so the SYSTEM removes it from the Lock Screen at `date` even if the app is
+    // killed and no push arrives. The activity keeps showing its last content
+    // (self-ticking Text(.timer) views keep counting), but it can no longer be
+    // updated and — per ActivityKit ended-state semantics — leaves the Dynamic
+    // Island. Note: iOS caps the post-end display window at 4 hours.
+    @available(iOS 16.1, *)
+    func scheduleEnd(activityId: String, endTimestampMs: Double, result: @escaping FlutterResult) {
+        Task {
+            let dismissalDate = Date(timeIntervalSince1970: endTimestampMs / 1000.0)
+            for activity in Activity<LiveActivitiesAppAttributes>.activities {
+                let customIdUuid = uuid5(name: activityId)
+                if activityId == activity.id ||
+                    activityId.uppercased() == activity.attributes.id.uuidString ||
+                    customIdUuid == activity.attributes.id {
+                    // Retain so endActivity can still force-dismiss the ended card.
+                    scheduledDismissalActivities[activityId] = activity
+                    await activity.end(dismissalPolicy: .after(dismissalDate))
+                    break
+                }
+            }
+            result(nil)
+        }
+    }
+
     @available(iOS 16.1, *)
     func endAllActivities(result: @escaping FlutterResult) {
         Task {
@@ -502,6 +544,15 @@ public class LiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                     await activity.end(dismissalPolicy: .immediate)
                     break
                 }
+            }
+        }
+        // Activities ended via scheduleEnd are no longer in Activity.activities
+        // but may still be visible until their dismissal date — re-end the
+        // retained reference to clear them now (e.g. the user unmuted early).
+        for id in activityIds {
+            if let activity = scheduledDismissalActivities.removeValue(forKey: id)
+                as? Activity<LiveActivitiesAppAttributes> {
+                await activity.end(dismissalPolicy: .immediate)
             }
         }
     }

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -122,6 +122,21 @@ class LiveActivities {
     return LiveActivitiesPlatform.instance.endActivity(activityId, activityTag);
   }
 
+  /// Ends the activity now with ActivityKit `dismissalPolicy: .after(at)` so
+  /// the SYSTEM removes it from the Lock Screen at [at] — even if the app is
+  /// killed and no push arrives.
+  ///
+  /// Trade-offs (ActivityKit ended-state semantics):
+  /// - the activity leaves the Dynamic Island immediately;
+  /// - it can no longer be updated (self-ticking `Text(.timer)` views keep
+  ///   counting on the Lock Screen card);
+  /// - iOS caps the post-end display window at 4 hours.
+  ///
+  /// A later [endActivity] on the same id force-dismisses the lingering card.
+  Future scheduleEnd(String activityId, {required DateTime at}) {
+    return LiveActivitiesPlatform.instance.scheduleEnd(activityId, at);
+  }
+
   /// Get the activity state.
   /// If the activity is not found, `null` is returned.
   ///

--- a/lib/live_activities_method_channel.dart
+++ b/lib/live_activities_method_channel.dart
@@ -106,6 +106,14 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
   }
 
   @override
+  Future scheduleEnd(String activityId, DateTime at) async {
+    return methodChannel.invokeMethod('scheduleEnd', {
+      'activityId': activityId,
+      'endTimestamp': at.millisecondsSinceEpoch,
+    });
+  }
+
+  @override
   Future endAllActivities() async {
     return methodChannel.invokeMethod('endAllActivities');
   }

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -67,6 +67,11 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
     throw UnimplementedError('endActivity() has not been implemented.');
   }
 
+  /// System-side scheduled dismissal: end now with `dismissalPolicy: .after`.
+  Future scheduleEnd(String activityId, DateTime at) {
+    throw UnimplementedError('scheduleEnd() has not been implemented.');
+  }
+
   Future<List<String>> getAllActivitiesIds() {
     throw UnimplementedError('getAllActivitiesIds() has not been implemented.');
   }

--- a/test/live_activities_test.dart
+++ b/test/live_activities_test.dart
@@ -34,6 +34,11 @@ class MockLiveActivitiesPlatform
   }
 
   @override
+  Future scheduleEnd(String activityId, DateTime at) {
+    return Future.value();
+  }
+
+  @override
   Future<bool> areActivitiesSupported() {
     return Future.value(true);
   }


### PR DESCRIPTION
Right now `endActivity` is the only way to stop an activity, and it dismisses it
immediately. I ran into a case where I wanted to end one but have the system keep
it on the lock screen until a set time and then drop it on its own, even if the
app gets killed in the meantime and no push ever shows up.

ActivityKit already handles this with `end(dismissalPolicy: .after(date))`, it
just wasn't exposed anywhere, so this wires it up as `scheduleEnd`:

```dart
await liveActivities.scheduleEnd(activityId, at: endDate);
```

A couple of things about how `.after` actually behaves that tripped me up:

- the activity leaves the Dynamic Island right away
- you can't update it after that, but a `Text(.timer)` keeps counting down on the
  lock screen card by itself
- iOS won't keep it around more than 4 hours past the end call

One thing I had to work around: once you schedule the end, the activity is gone
from `Activity.activities`, so a plain `endActivity` can't find it to clear it
early. I keep a reference to the ended activity so `endActivity` can still kill
the card immediately if you need it gone before the timer's up (cancelled
countdown, etc.).

iOS 16.1+. Also added a `scheduleEnd` stub to the test mock so the platform
interface test still compiles.